### PR TITLE
Added link of Software Architect Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ If you think that these can be improved in anyway, please do suggest.
 ## Map
 ![Frame 7 2 (1)](https://user-images.githubusercontent.com/6892666/65896069-834eb700-e37a-11e9-95be-7ae2300d5d50.png)
 
+## Software Architect Roadmaps
+
+For more details on the road to become a software architect, check out the roadmap below:
+- [Software Architect Roadmap](https://roadmap.sh/software-architect)
+
 ## 🚦 Wrap Up
 
 If you have an idea to improve the map, feel free to discuss it in the issues.


### PR DESCRIPTION
Hi @stemmlerjs,

I came across your repository [software-design-and-architecture-roadmap](https://github.com/stemmlerjs/software-design-and-architecture-roadmap) and found it to be a valuable resource for Software Architect enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Software Architect Roadmap"](https://roadmap.sh/software-architect). I took the initiative to submit a ["Pull Request"](https://github.com/stemmlerjs/software-design-and-architecture-roadmap/pull/4) adding it in a separate ["Software Architect Roadmaps"]() section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz